### PR TITLE
Fjerner github-action-sanity

### DIFF
--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -22,8 +22,11 @@ jobs:
       - name: Yarn install
         run: yarn --prefer-offline --frozen-lockfile
 
-      - name: Installer sanity
-        run: yarn global add @sanity/cli && sanity install
+      - name: Add sanity
+        run: yarn global add @sanity/cli
+
+      - name: Sanity install
+        run: sanity install
 
       - name: Deploy sanity
         env:

--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -18,10 +18,14 @@ jobs:
         with:
           node-version: "20"
           cache: yarn
+
       - name: Yarn install
         run: yarn --prefer-offline --frozen-lockfile
-      - uses: sanity-io/github-action-sanity@v0.7-alpha
+
+      - name: Installer sanity
+        run: yarn global add @sanity/cli && sanity install
+
+      - name: Deploy sanity
         env:
           SANITY_AUTH_TOKEN: ${{ secrets.SANITY_DEPLOY_TOKEN_NY }}
-        with:
-          args: deploy
+        run: sanity deploy


### PR DESCRIPTION
Fjerner github-action-sanity, da den var er på node versjon 18. Dette gjør at andre dependencies ikke kan bumpes.
github-action-sanity ble brukt til å deploye sanity, men har lagt til et ekstra steg hvor sanity blir installert, slik at sanity cli kan fortsette å deploye